### PR TITLE
bug_fix

### DIFF
--- a/kmcpy/model.py
+++ b/kmcpy/model.py
@@ -350,7 +350,7 @@ class LocalClusterExpansion:
             d = {
                 "@module": self.__class__.__module__,
                 "@class": self.__class__.__name__,
-                "center_Na1": self.center_Na1.as_dict(),
+                "center_site": self.center_site.as_dict(),
                 "MigrationUnit_structure": self.MigrationUnit_structure.as_dict(),
                 "clusters": [],
                 "orbits": [],


### PR DESCRIPTION
The center_site call for `api==1` is hardcoded for Na. Is this just a mistake? In that case if statement when calling as_dict differentiating between the self.api variable will be reduntdant. Correct me if I am wrong