### PR TITLE
Update kmc.py

### DIFF
--- a/kmcpy/kmc.py
+++ b/kmcpy/kmc.py
@@ -253,7 +253,7 @@ class KMC:
         self.occ_global[event.mobile_ion_specie_1_index] *= -1
         self.occ_global[event.mobile_ion_specie_2_index] *= -1
         events_to_be_updated = copy(
-            self.site_event_list[event.mobile_ion_specie_2_index]
+            self.site_event_list[event.mobile_ion_specie_2_index]+self.site_event_list[event.mobile_ion_specie_1_index]
         )  # event_to_be_updated= list, include the indices, of the event that need to be updated.
         for e_index in events_to_be_updated:
             events[e_index].update_event(


### PR DESCRIPTION
This pull request includes a small but important change to the `update` method in `kmcpy/kmc.py`. The change ensures that events associated with both `mobile_ion_specie_1_index` and `mobile_ion_specie_2_index` are included in the `events_to_be_updated` list, improving the accuracy of event updates. The discussion of this bug is in #31 

* [`kmcpy/kmc.py`](diffhunk://#diff-d2a64d21774db053dffc9f7b5af14a318a11608726e981cfeb6697bf03e2b704L256-R256): Modified the `update` method to append `self.site_event_list[event.mobile_ion_specie_1_index]` to `self.site_event_list[event.mobile_ion_specie_2_index`, ensuring both sets of events are considered for updates.
