### PR TITLE
Bump version to 0.2.4 in CITATION.cff, doc_requirements.txt, NASICON.…

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: If you use this work, please cite the following publications.
 title: kMCpy
-version: v0.2.3 # replace with whatever version you use
+version: v0.2.4 # replace with whatever version you use
 date-released: '2023-10-05'
 authors:
 - family-names: Deng

--- a/docs/doc_requirements.txt
+++ b/docs/doc_requirements.txt
@@ -25,7 +25,7 @@ jupyter-client==8.8.0
 jupyter-core==5.9.1
 jupyterlab-pygments==0.3.0
 kiwisolver==1.4.9
-kmcpy==0.2.3
+kmcpy==0.2.4
 llvmlite==0.46.0
 markdown-it-py==4.0.0
 markupsafe==3.0.3

--- a/example/NASICON.ipynb
+++ b/example/NASICON.ipynb
@@ -45,7 +45,7 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Requirement already satisfied: kmcpy in /usr/local/lib/python3.12/dist-packages (0.2.3)\n",
+            "Requirement already satisfied: kmcpy in /usr/local/lib/python3.12/dist-packages (0.2.4)\n",
             "Requirement already satisfied: glob2>=0.7 in /usr/local/lib/python3.12/dist-packages (from kmcpy) (0.7)\n",
             "Requirement already satisfied: joblib>=1.5.1 in /usr/local/lib/python3.12/dist-packages (from kmcpy) (1.5.1)\n",
             "Requirement already satisfied: numba>=0.61.2 in /usr/local/lib/python3.12/dist-packages (from kmcpy) (0.61.2)\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kmcpy"
-version = "v0.2.3" # << REMEMBER TO UPDATE THIS FOR EACH RELEASE
+version = "0.2.4" # << REMEMBER TO UPDATE THIS FOR EACH RELEASE
 description = "Kinetic Monte Carlo Simulation using Python (kMCpy)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -776,7 +776,7 @@ wheels = [
 
 [[package]]
 name = "kmcpy"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "glob2" },


### PR DESCRIPTION
This pull request updates the project version from 0.2.3 to 0.2.4 across the codebase to ensure consistency and reflect the new release. The changes affect version references in documentation, configuration, and example files.

Version bump and consistency updates:

* Updated the project version to `0.2.4` in `pyproject.toml`, removing the leading "v" for consistency with Python packaging standards.
* Updated the version in `CITATION.cff` to `v0.2.4` to match the new release.
* Updated the `kmcpy` dependency version to `0.2.4` in `docs/doc_requirements.txt`.
* Updated example output in `example/NASICON.ipynb` to reflect the new `kmcpy` version.