### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kmcpy"
-version = "0.2.5" # << REMEMBER TO UPDATE THIS FOR EACH RELEASE
+version = "0.3.0" # << REMEMBER TO UPDATE THIS FOR EACH RELEASE
 description = "Kinetic Monte Carlo Simulation using Python (kMCpy)"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump package version from 0.2.5 to 0.3.0 in pyproject metadata.

## Why
- Development has moved beyond the existing v0.2.5 tag and includes API/model cleanup that should be released as 0.3.0.

## Validation
- Parsed pyproject.toml and confirmed project.version is 0.3.0.
- Refreshed editable install with uv pip install -e . and confirmed kmcpy.__version__ reports 0.3.0.