### PR TITLE
Improve documentation workflow structure

### DIFF
--- a/docs/source/howto/index.md
+++ b/docs/source/howto/index.md
@@ -1,9 +1,9 @@
-# Advanced Tutorials
+# Advanced Overview
 
 Use these pages after you understand the basic kMCpy workflow. They focus on
 customization, external interfaces, and order-sensitive model details.
 
-For a beginner path, start with the [tutorial workflow](../tutorial/index.md).
+For the main workflow, start with the [tutorial overview](../tutorial/index.md).
 
 ## Simulation Customization
 
@@ -18,8 +18,9 @@ For a beginner path, start with the [tutorial workflow](../tutorial/index.md).
   count-based, species-count, wildcard, and exact local-environment barriers.
 - [Choose basis functions](basis_functions.md): understand occupation and
   Chebyshev basis functions for binary and multicomponent sites.
-- [Prepare NEB fitting inputs](neb_fitting.md): turn NEB structures and
-  barriers into fitting files for a local cluster expansion.
+- [Prepare NEB fitting inputs](neb_fitting.md): lower-level details for turning
+  NEB structures and barriers into fitting files after the main
+  [LCE workflow](../tutorial/local_environments_neb.md).
 
 ## Site Order And External Codes
 

--- a/docs/source/howto/neb_fitting.md
+++ b/docs/source/howto/neb_fitting.md
@@ -1,5 +1,9 @@
 # Prepare NEB Fitting Inputs
 
+For a first pass through the workflow, start with the beginner page
+[Local Environments And NEB Data](../tutorial/local_environments_neb.md). This
+page gives lower-level details for `NEBDataLoader`.
+
 Use `NEBDataLoader` when you have NEB barriers for a list of structures and
 want to fit a `LocalClusterExpansion`.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,8 +34,8 @@ Where to start:
 
 1. Install kMCpy using :doc:`install`.
 2. Run one small simulation with :doc:`quickstart`.
-3. Learn the full beginner workflow in :doc:`tutorial/index`.
-4. Use :doc:`mechanism` for the kMC equations and transport definitions.
+3. Read :doc:`mechanism` for the kMC equations and transport definitions.
+4. Learn the full workflow in :doc:`tutorial/index`.
 5. Use :doc:`howto/index` for advanced customization.
 6. Use :doc:`reference/index` when you need exact API documentation.
 
@@ -51,19 +51,19 @@ electrolytes. See :doc:`about` for citation information.
 
 .. toctree::
    :maxdepth: 1
-   :caption: Beginner Tutorial
-
-   tutorial/index
-
-.. toctree::
-   :maxdepth: 1
    :caption: Theory
 
    mechanism
 
 .. toctree::
    :maxdepth: 1
-   :caption: Advanced Tutorials
+   :caption: Tutorial
+
+   tutorial/index
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Advanced
 
    howto/index
 

--- a/docs/source/mechanism.md
+++ b/docs/source/mechanism.md
@@ -8,7 +8,7 @@ between crystallographic sites. Each accepted hop changes the occupation state,
 advances the simulation clock, and updates the affected event rates.
 
 This page focuses on the equations. For how to prepare structures, event
-libraries, and models, see the [beginner tutorial](tutorial/index.md).
+libraries, and models, see the [workflow tutorial](tutorial/index.md).
 
 ## Rejection-Free Algorithm
 

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -69,7 +69,7 @@ A kMC run needs:
 - initial occupations,
 - runtime settings such as temperature, attempt frequency, and number of passes.
 
-The beginner tutorial explains how to prepare each part.
+The workflow tutorial explains how to prepare each part.
 
 ## Inspect Configuration Fields
 

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -1,9 +1,9 @@
-# Reference
+# Reference Overview
 
 Use the reference section when you need exact API names, class signatures, or
 module-level documentation. For task-oriented workflows, start with the
-[beginner tutorial](../tutorial/index.md) or
-[advanced tutorials](../howto/index.md).
+[workflow tutorial](../tutorial/index.md) or
+[advanced pages](../howto/index.md).
 
 ## API Reference
 

--- a/docs/source/tutorial/analysis.md
+++ b/docs/source/tutorial/analysis.md
@@ -64,5 +64,7 @@ Record:
 - equilibration and production passes,
 - random seed strategy.
 
-The `Configuration` and model files are designed to make this information easy
-to keep with the results.
+The [`Configuration`](../modules/config.rst) and model files are designed to
+make this information easy to keep with the results.
+
+Next: [Units And Interoperability](units_interoperability.md).

--- a/docs/source/tutorial/events.md
+++ b/docs/source/tutorial/events.md
@@ -2,7 +2,9 @@
 
 The event library contains the allowed hops and the dependency information
 needed to update affected rates after a hop. Events are stored in the same
-active-site order as the simulation occupations.
+active-site order as the simulation occupations. Build it after the
+[`site_mapping`](structure.md) is fixed and before writing the final
+[`Configuration`](run_kmc.md).
 
 ## Generate Events
 
@@ -30,6 +32,21 @@ generator.generate_events(
 
 `event_file` is a bundled event library. It contains both events and event
 dependencies, so a separate dependency CSV is not needed for new workflows.
+
+The important [`EventGenerator.generate_events(...)`](../modules/generators.rst)
+arguments are:
+
+- `structure_file`: CIF or structure file containing all possible mobile-ion
+  sites.
+- `site_mapping`: same active-site convention used by the structure, model, and
+  simulation configuration.
+- `supercell_shape`: event-library supercell relative to the input structure.
+- `mobile_species`: species that can hop.
+- `mobile_ion_identifiers`: optional pair of labels or species identifiers used
+  to restrict hop endpoints.
+- `local_env_cutoff`: local-environment cutoff in angstrom used for event
+  dependencies and local model updates.
+- `event_file`: output event-library JSON.
 
 ## Species And Label Selection
 
@@ -79,3 +96,8 @@ After generation, inspect:
 - whether the supercell shape is large enough for the desired kMC cell,
 - whether the event library was generated with the same `site_mapping` used by
   the simulation.
+
+Next:
+
+- local barrier branch: [Prepare Input And Run kMC](run_kmc.md);
+- LCE branch: [Local Environments And NEB Data](local_environments_neb.md).

--- a/docs/source/tutorial/index.md
+++ b/docs/source/tutorial/index.md
@@ -1,17 +1,19 @@
-# Beginner Tutorial
+# Workflow Overview
 
-This tutorial teaches the workflow, not the internals. A kMCpy simulation needs
-a small set of scientific inputs:
+This tutorial follows the order of a kMCpy study. It teaches how the scientific
+inputs are prepared before showing how those inputs are loaded into a run.
+
+Every kMCpy simulation needs a small set of inputs:
 
 - a crystal structure containing every possible mobile-ion site,
 - a site mapping that defines mobile-ion and vacancy states,
 - an event library describing allowed hops and event dependencies,
-- a model that gives each event a rate,
+- a rate model,
 - an initial occupation vector,
 - runtime settings,
 - a tracker for output and analysis.
 
-The workflow is:
+The common workflow is:
 
 ```text
 structure or CIF
@@ -19,12 +21,16 @@ structure or CIF
       v
 site_mapping and active-site order
       |
-      +--> event library and dependencies
+      +--> event library
       |
-      +--> local environments, NEB data, and model fitting
+      +--> rate model branch
+              |
+              +--> LocalBarrierModel rules
+              |
+              +--> LocalClusterExpansion local environments -> NEB/calculated data -> fit
                     |
                     v
-              model file
+                 model file
       |
       v
 Configuration + initial occupations
@@ -33,9 +39,26 @@ Configuration + initial occupations
 KMC run -> Tracker -> results and analysis
 ```
 
-Read the pages in order the first time. Later, you can jump to the advanced
-tutorials for custom properties, custom models, local barrier rules, basis
-functions, and external-code adapters.
+There are two common model branches:
+
+- **Local barrier branch**: write explicit barriers with
+  [`LocalBarrierModel`](../modules/local_barrier_model.rst). You do not need
+  NEB enumeration or fitting unless you want exact local-environment rules from
+  calculated barriers.
+- **LCE branch**: build a
+  [`LocalClusterExpansion`](../modules/local_cluster_expansion.rst), enumerate
+  local environments, collect NEB or other target data, fit coefficients, then
+  use the fitted model in kMC.
+
+Read [Structure And Active Sites](structure.md), [Choose And Build A
+Model](models.md), and [Build The Event Library](events.md) first. If you use
+the LCE branch, continue through [Local Environments And NEB Data](local_environments_neb.md)
+and [Fit A Local Cluster Expansion](lce_fitting.md) before running kMC. If you
+use a local barrier model, you can skip directly to [Prepare Input And Run
+kMC](run_kmc.md).
+
+Advanced pages cover custom properties, custom models, advanced local barrier
+rules, basis functions, local site order, and external-code adapters.
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/source/tutorial/lce_fitting.md
+++ b/docs/source/tutorial/lce_fitting.md
@@ -1,40 +1,12 @@
 # Fit A Local Cluster Expansion
 
-This page explains the structure of an LCE and how to fit it from local
-environment data.
+This page starts after you have built the
+[`LocalClusterExpansion`](../modules/local_cluster_expansion.rst) in
+[Choose And Build A Model](models.md) and written fitting files with
+[`NEBDataLoader`](../modules/neb.rst) in [Local Environments And NEB Data](local_environments_neb.md).
 
-## LCE Objects
-
-An LCE starts from a `LocalLatticeStructure`. This object defines:
-
-- the local-environment center,
-- the cutoff sphere,
-- the local site order,
-- the basis function used to encode species states.
-
-```python
-from pymatgen.core import Structure
-from kmcpy.structure import LocalLatticeStructure
-from kmcpy.models import LocalClusterExpansion
-
-structure = Structure.from_file("nasicon.cif")
-site_mapping = {"Na": ["Na", "X"], "Zr": "Zr", "Si": ["Si", "P"], "O": "O"}
-
-local_lattice = LocalLatticeStructure(
-    template_structure=structure,
-    center=0,
-    cutoff=4.0,
-    site_mapping=site_mapping,
-    basis_type="chebyshev",
-    local_site_order="kmcpy_default",
-)
-
-lce = LocalClusterExpansion()
-lce.build(local_lattice_structure=local_lattice, cutoff_cluster=[6.0, 6.0, 0.0])
-```
-
-`center` chooses the local-environment origin. `local_site_order` only controls
-how selected local sites are ordered and whether a real center site is excluded.
+Fitting does not decide the local environment. It only finds coefficients for
+the fixed feature order already defined by the LCE object.
 
 ## Cluster, Orbit, Correlation
 
@@ -61,22 +33,43 @@ functions, so multicomponent sites add more decorated features.
 
 ## Fit Parameters
 
-After writing fitting inputs with `NEBDataLoader`, fit the coefficients:
+After writing fitting inputs with `NEBDataLoader.write_fitting_inputs(...)`, fit
+the coefficients:
 
 ```python
-params, y_pred, y_true = lce.fit(
+fit_files = loader.write_fitting_inputs(output_dir="fit_kra")
+
+params, y_pred, y_true = kra_lce.fit(
+    **fit_files,
     alpha=1e-4,
-    corr_fname="fit_kra/correlation_matrix.txt",
-    ekra_fname="fit_kra/e_kra.txt",
-    weight_fname="fit_kra/weight.txt",
     lce_params_fname="fit_kra/lce_params.json",
 )
 
-lce.set_parameters(params)
-lce.to("kra_lce.json")
+kra_lce.set_parameters(params)
+kra_lce.to("kra_lce.json")
 ```
 
-For a composite model, fit the KRA LCE and site-energy-difference LCE
+The important [`LocalClusterExpansion.fit(...)`](../modules/local_cluster_expansion.rst)
+arguments are:
+
+- `alpha`: Lasso regularization strength. Larger values usually produce fewer
+  active coefficients.
+- `corr_fname`: correlation matrix file from `NEBDataLoader`.
+- `ekra_fname`: target-value file. The name is historical; the values can be
+  `E_KRA` or another fitted scalar as long as the model usage is consistent.
+- `weight_fname`: sample weights, one per target value.
+- `lce_params_fname`: output JSON for fitted coefficients and metadata.
+- `max_iter`: maximum Lasso iterations.
+
+`fit(...)` returns:
+
+- `params`: fitted LCE parameters.
+- `y_pred`: model predictions for the training rows.
+- `y_true`: target values loaded from `ekra_fname`.
+
+Call `set_parameters(params)` before saving or using the LCE in kMC.
+
+For a composite model, fit the KRA LCE and site-energy-difference model
 separately, then combine them:
 
 ```python
@@ -85,6 +78,8 @@ from kmcpy.models import CompositeLCEModel
 model = CompositeLCEModel(kra_model=kra_lce, site_model=site_lce)
 model.to("model.json")
 ```
+
+If you only have a KRA model, omit `site_model`.
 
 ## Underfit And Overfit
 
@@ -113,3 +108,5 @@ Before using an LCE in kMC:
 - inspect RMSE and LOOCV,
 - keep the model, fitting parameters, local site order, and training data
   together.
+
+Next: [Prepare Input And Run kMC](run_kmc.md).

--- a/docs/source/tutorial/local_environments_neb.md
+++ b/docs/source/tutorial/local_environments_neb.md
@@ -1,12 +1,18 @@
 # Local Environments And NEB Data
 
-Local models need local structures. For LCE fitting, every target value must be
-paired with the same ordered local occupation vector used by the model.
+This page is for the LCE branch of the workflow. If you use a
+[`LocalBarrierModel`](../modules/local_barrier_model.rst) with hand-written
+rules, you can skip this page and continue to [Prepare Input And Run kMC](run_kmc.md).
+
+For LCE fitting, every target value must be paired with the same ordered local
+occupation vector used by the [`LocalClusterExpansion`](../modules/local_cluster_expansion.rst)
+built in [Choose And Build A Model](models.md).
 
 ## Enumerate Local Environments
 
-Use local-environment enumeration when you want to generate representative
-ordered configurations around a hop:
+Use [`enumerate_neb_endpoint_pairs`](../modules/local_environment_enumerator.rst)
+when you want to generate representative ordered configurations around one hop
+and turn each configuration into an initial/final NEB endpoint pair:
 
 ```python
 from pymatgen.core import Structure
@@ -25,6 +31,7 @@ lattice = LatticeStructure(
 endpoint_pairs = enumerate_neb_endpoint_pairs(
     lattice_structure=lattice,
     mobile_ion_indices=(0, 1),
+    center=0,
     cutoff=4.0,
     variable_species=["Si", "P"],
     max_results=20,
@@ -32,21 +39,48 @@ endpoint_pairs = enumerate_neb_endpoint_pairs(
 )
 ```
 
+This uses [`LatticeStructure`](../modules/lattice_structure.rst), the global
+active-site lattice. The LCE itself uses `LocalLatticeStructure`, the local
+reference extracted from the same structure and `site_mapping`. Keep both built
+from the same structure convention.
+
+The important arguments are:
+
+- `lattice_structure`: global structure model with the same `site_mapping` used
+  by the simulation.
+- `mobile_ion_indices`: compact active-site indices for the hop endpoints.
+  These should correspond to the event you plan to fit.
+- `center`: local-environment origin. If omitted, kMCpy uses the initial
+  mobile-ion site.
+- `cutoff`: local-environment radius in angstrom.
+- `variable_species`: species that may be enumerated on selected active sites.
+- `variable_site_indices`: optional compact active-site indices to vary. If
+  omitted, kMCpy varies active sites in the local environment that can host
+  `variable_species`.
+- `species_counts`: optional exact composition constraint, such as
+  `{"Si": 2, "P": 1}`.
+- `local_site_order`: must match the order used when building the LCE.
+- `max_results`: safety limit on the number of generated environments.
+
 Each endpoint pair contains an initial structure, a final structure, and the
 initial/final occupation vectors. The structures can be written and used as the
-starting point for NEB calculations.
+starting point for NEB calculations. kMCpy does not create VASP input files or
+interpolated images; it prepares the ordered endpoints and metadata.
+
+For more enumeration options, see [Enumerate Local Environments](../howto/local_environment_enumeration.md).
 
 ## Load NEB Results
 
 After NEB calculations finish, collect the endpoint-derived structures and the
 computed target values. The target can be an `E_KRA` barrier or a site-energy
-difference, depending on which LCE you are fitting.
+difference, depending on which LCE you are fitting. The example below uses
+`kra_lce` and `local_lattice` from [Choose And Build A Model](models.md).
 
 ```python
 from kmcpy.io.neb import NEBDataLoader
 
 loader = NEBDataLoader(
-    model=lce,
+    model=kra_lce,
     reference_local_lattice_structure=local_lattice,
 )
 loader.add_structures(
@@ -57,6 +91,15 @@ loader.add_structures(
 fit_files = loader.write_fitting_inputs(output_dir="fit_kra")
 ```
 
+The important [`NEBDataLoader`](../modules/neb.rst) arguments are:
+
+- `model`: the LCE whose correlation vector will be evaluated.
+- `reference_local_lattice_structure`: the same local lattice used to build the
+  LCE. This keeps the occupation vector order fixed.
+- `structures`: endpoint-derived structures or paths readable by pymatgen.
+- `property_values`: target values in meV, one per structure.
+- `output_dir`: directory for the fitting input files.
+
 `write_fitting_inputs(...)` writes:
 
 - `correlation_matrix.txt`,
@@ -64,6 +107,14 @@ fit_files = loader.write_fitting_inputs(output_dir="fit_kra")
 - `weight.txt`.
 
 These are the files consumed by `LocalClusterExpansion.fit(...)`.
+The returned dictionary can be passed directly into the fitting call on the next
+page:
+
+```python
+fit_files = loader.write_fitting_inputs(output_dir="fit_kra")
+# later:
+# params, y_pred, y_true = kra_lce.fit(**fit_files, alpha=1e-4)
+```
 
 ## Keep The Reference Fixed
 
@@ -76,3 +127,5 @@ site order used to build the correlation matrix. Do not mix:
 - correlation matrices from different LCE objects.
 
 If you change any of these, regenerate the fitting inputs.
+
+Next: [Fit A Local Cluster Expansion](lce_fitting.md).

--- a/docs/source/tutorial/models.md
+++ b/docs/source/tutorial/models.md
@@ -1,18 +1,20 @@
-# Choose A Model
+# Choose And Build A Model
 
 Every kMC event needs a rate. In kMCpy, rates come from a model. Choose the
-smallest model that represents the physics you need.
+smallest model that represents the physics you need, then build that model
+before preparing the final simulation input.
 
 | Model | Use When | Data Needed |
 |---|---|---|
-| `LocalBarrierModel` | Barriers can be written as explicit local rules. | Constants, count rules, wildcard rules, or exact local environments. |
-| `LocalClusterExpansion` | Barriers or site-energy differences should be fitted from local-environment data. | NEB or other calculated targets and matching local structures. |
-| `CompositeLCEModel` | You have an LCE for `E_KRA` and optionally another model for site-energy differences. | A fitted KRA LCE and optional site model. |
-| `SiteEnergyModel` | A callable or external code supplies site-energy differences. | A runtime object or callable plus site/state mappings if needed. |
+| [`LocalBarrierModel`](../modules/local_barrier_model.rst) | Barriers can be written as explicit local rules. | Constants, count rules, wildcard rules, or exact local environments. |
+| [`LocalClusterExpansion`](../modules/local_cluster_expansion.rst) | A local scalar should be fitted from local-environment data. | A reference local lattice, cluster cutoffs, and fitted coefficients from NEB or other target data. |
+| [`CompositeLCEModel`](../modules/composite_lce_model.rst) | You have one model for `E_KRA` and optionally another model for site-energy differences. | A fitted KRA model and optional site-energy-difference model. |
+| [`SiteEnergyModel`](../modules/site_energy.rst) | A callable or external code supplies site-energy differences. | A runtime object or callable plus site/state mappings. |
 
-## LocalBarrierModel
+## Local Barrier Branch
 
-Use `LocalBarrierModel` when the rule is direct and readable:
+Use `LocalBarrierModel` when the barrier rule is direct and readable. A constant
+barrier is the smallest valid model:
 
 ```python
 from kmcpy.models import LocalBarrierModel
@@ -21,50 +23,129 @@ model = LocalBarrierModel.constant_barrier(300.0)  # meV
 model.to("local_barrier_model.json")
 ```
 
-Rules are evaluated in order. The first match provides the barrier. A common
-pattern is to put specific rules first and a default barrier last:
+`constant_barrier(barrier)` takes one required argument:
+
+- `barrier`: activation barrier in meV, used for every valid event.
+
+Rules are evaluated in order. The first matching rule provides the barrier; if
+no rule matches, `default_barrier` is used. For species-count rules, provide
+`site_species` so kMCpy can translate each active-site occupation state into a
+chemical label:
 
 ```python
 from kmcpy.models import LocalBarrierModel
 
 model = LocalBarrierModel(
     default_barrier=350.0,
-    rules=[
-        {
-            "type": "species_count",
-            "species": "Si",
-            "min_count": 3,
-            "barrier": 420.0,
-        },
-    ],
+    site_species={
+        5: {0: "P", 1: "Si"},
+        6: {0: "Si", 1: "P"},
+        7: {0: "Al", 1: "Si"},
+        8: {0: "Si", 1: "P"},
+    },
+)
+model.add_species_count_rule(
+    name="si_rich",
+    sites="local_env",
+    species="Si",
+    min_count=3,
+    barrier=420.0,
+)
+model.to("local_barrier_model.json")
+```
+
+The important arguments are:
+
+- `default_barrier`: fallback barrier in meV.
+- `site_species`: mapping `{active_site_index: {state_index: species_label}}`
+  used by species-count rules.
+- `sites`: which sites the rule counts. `"local_env"` counts the event local
+  environment. `"canonical"` counts the two mobile-ion endpoints followed by
+  the local-environment sites with duplicates removed.
+- `min_count`, `max_count`, or `count`: the count condition.
+- `barrier`: barrier in meV returned when the rule matches.
+
+For exact-match tables, wildcard patterns, and more rule examples, see
+[Use advanced local barrier rules](../howto/local_barrier_model.md).
+
+## LCE Branch
+
+Use `LocalClusterExpansion` when a local scalar should be fitted from local
+environment data. The scalar can be `E_KRA`, a site-energy-difference term, or
+another model quantity. The meaning comes from where the LCE is used later.
+
+An LCE is built in two stages:
+
+1. Build a [`LocalLatticeStructure`](../modules/local_lattice_structure.rst).
+   This defines the local environment and the local site order.
+2. Build the [`LocalClusterExpansion`](../modules/local_cluster_expansion.rst).
+   This enumerates point, pair, triplet, and quadruplet clusters inside the
+   local environment.
+
+```python
+from pymatgen.core import Structure
+
+from kmcpy.models import LocalClusterExpansion
+from kmcpy.structure import LocalLatticeStructure
+
+structure = Structure.from_file("nasicon.cif")
+site_mapping = {
+    "Na": ["Na", "X"],
+    "Zr": "Zr",
+    "Si": ["Si", "P"],
+    "O": "O",
+}
+
+local_lattice = LocalLatticeStructure(
+    template_structure=structure,
+    center=0,
+    cutoff=4.0,
+    site_mapping=site_mapping,
+    basis_type="chebyshev",
+    local_site_order="kmcpy_default",
+)
+
+kra_lce = LocalClusterExpansion()
+kra_lce.build(
+    local_lattice_structure=local_lattice,
+    cutoff_cluster=[6.0, 6.0, 0.0],
 )
 ```
 
-This is transparent and easy to debug, but it does not interpolate beyond the
-rules you write.
+The important `LocalLatticeStructure` arguments are:
 
-## LocalClusterExpansion
+- `template_structure`: structure containing every possible mobile-ion site.
+- `center`: local-environment origin. It can be a structure site index or a
+  fractional-coordinate point. If it is a real site, the local site order
+  controls whether the center is included in the occupation vector.
+- `cutoff`: radius used to select local-environment sites.
+- `site_mapping`: allowed occupation states for active sites and fixed species
+  for inactive sites.
+- `basis_type`: occupation encoding. Use `"chebyshev"` for multicomponent
+  active sites.
+- `local_site_order`: deterministic order for the local occupation vector. See
+  [Control local site order](../howto/local_site_order.md).
 
-A `LocalClusterExpansion` maps a local occupation vector around an event to a
-scalar:
+The important `LocalClusterExpansion.build(...)` arguments are:
+
+- `local_lattice_structure`: the ordered local lattice just built.
+- `cutoff_cluster`: `[pair, triplet, quadruplet]` cutoffs in angstrom. The LCE
+  always includes point clusters; the list controls higher-body clusters.
+
+The fitted scalar is
 
 $$
 y(\sigma) = E_0 + \sum_j \alpha_j \Phi_j(\sigma)
 $$
 
-where `sigma` is the ordered local occupation vector, `Phi_j` are cluster
-features, and `alpha_j` are fitted coefficients.
+where `sigma` is the ordered local occupation vector, `Phi_j` are decorated
+cluster-orbit features, and `alpha_j` are fitted coefficients.
 
-The same `LocalClusterExpansion.compute(...)` method is used for any fitted
-scalar. Its meaning comes from where the LCE is used:
+At this point the LCE has the correct feature order, but it has no fitted
+coefficients. Continue to [Local Environments And NEB Data](local_environments_neb.md)
+and [Fit A Local Cluster Expansion](lce_fitting.md).
 
-- as `kra_model`, it returns `E_KRA`;
-- as `site_model`, it returns the fitted site-energy-difference contribution for
-  the canonical event orientation.
-
-This avoids separate user-facing compute APIs for barrier and site terms.
-
-## CompositeLCEModel
+## Composite LCE Models
 
 For transition-state-theory rates, kMCpy can combine a KRA model and a
 site-energy-difference model:
@@ -87,12 +168,19 @@ $$
 
 where the site model provides the signed event energy change.
 
-## SiteEnergyModel
+The same `LocalClusterExpansion.compute(...)` method is used for any fitted
+scalar:
+
+- as `kra_model`, it returns `E_KRA`;
+- as `site_model`, it returns the fitted site-energy-difference contribution for
+  the canonical event orientation.
+
+## External Site-Energy Models
 
 Use `SiteEnergyModel` when an external runtime, such as a cluster-expansion
 evaluator, supplies only the site-energy difference. kMCpy initializes the
 external occupation once, precomputes array-backed site/state mappings, and then
-passes only the two changed endpoints to the callable for each proposed event.
+passes only the changed endpoints to the callable for each proposed event.
 
-This is the right direction when a full occupation conversion at every kMC step
-would be too slow.
+See [Use site-energy-difference models](../howto/external_site_energy.md) for
+the external-code workflow.

--- a/docs/source/tutorial/run_kmc.md
+++ b/docs/source/tutorial/run_kmc.md
@@ -1,7 +1,7 @@
 # Prepare Input And Run kMC
 
 After the structure, event library, model, and initial occupations are ready,
-put them into a `Configuration`.
+put them into a [`Configuration`](../modules/config.rst).
 
 ## Create A Configuration In Python
 
@@ -31,8 +31,21 @@ config = Configuration(
 tracker = run(config)
 ```
 
-`run(config)` creates a `KMC` object, loads the model and event library, runs the
-simulation, writes standard outputs, and returns the `Tracker`.
+[`run(config)`](../modules/high_level_api.rst) creates a `KMC` object, loads the
+model and event library, runs the simulation, writes standard outputs, and
+returns the [`Tracker`](../modules/tracker.rst).
+
+The important `Configuration` fields are:
+
+- `structure_file`, `model_file`, `event_file`: loader paths used to start the
+  run.
+- `initial_occupations`: active-site occupation vector from
+  [Prepare Structures And Occupations](structure.md).
+- `supercell_shape`, `site_mapping`: must match the event library and model.
+- `temperature`, `attempt_frequency`: rate-model runtime conditions.
+- `equilibration_passes`, `kmc_passes`, `random_seed`: simulation controls.
+- `mobile_ion_specie`, `mobile_ion_charge`, `elementary_hop_distance`,
+  `dimension`: transport-output metadata.
 
 ## Write A Reloadable Input File
 
@@ -82,3 +95,5 @@ for temperature in [300.0, 400.0, 500.0]:
 
 Keep the event library and model fixed unless the physical system or active-site
 order changes.
+
+Next: [Track Outputs](tracker_outputs.md).

--- a/docs/source/tutorial/structure.md
+++ b/docs/source/tutorial/structure.md
@@ -71,9 +71,9 @@ In this example:
 - Si sites are active substitutional sites. They can be `Si` or `P`.
 - Zr and O sites are fixed because only one species is allowed.
 
-kMCpy builds an `ActiveSiteOrder` from the structure and `site_mapping`. This is
-the compact global sequence used by occupation vectors, event indices, and
-external site-energy mappings.
+kMCpy builds an [`ActiveSiteOrder`](../modules/active_site_order.rst) from the
+structure and `site_mapping`. This is the compact global sequence used by
+occupation vectors, event indices, and external site-energy mappings.
 
 ## Prepare Initial Occupations
 
@@ -98,11 +98,15 @@ active-site order.
 
 ## Two Site Orders To Remember
 
-`ActiveSiteOrder` is the global active-site sequence used by kMC.
+[`ActiveSiteOrder`](../modules/active_site_order.rst) is the global active-site
+sequence used by kMC.
 
-`LocalSiteOrder` is the local environment sequence used by an LCE correlation
-vector around one event. It does not choose the local-environment center; the
-center is supplied by `LocalLatticeStructure`.
+[`LocalSiteOrder`](../modules/local_site_order.rst) is the local environment
+sequence used by an LCE correlation vector around one event. It does not choose
+the local-environment center; the center is supplied by
+[`LocalLatticeStructure`](../modules/local_lattice_structure.rst).
 
 This distinction matters most when reusing fitted LCE coefficients or mapping
 kMCpy occupations to external codes.
+
+Next: [Choose And Build A Model](models.md).

--- a/docs/source/tutorial/tracker_outputs.md
+++ b/docs/source/tutorial/tracker_outputs.md
@@ -1,7 +1,8 @@
 # Tracker And Output Files
 
-`KMC` runs the algorithm. `State` owns the mutable occupations. `Tracker`
-observes the trajectory and writes output.
+[`KMC`](../modules/kmc.rst) runs the algorithm.
+[`State`](../modules/state.rst) owns the mutable occupations.
+[`Tracker`](../modules/tracker.rst) observes the trajectory and writes output.
 
 ## Built-In Outputs
 
@@ -70,3 +71,5 @@ tracker.write_results(label="extra_label")
 
 For advanced property scheduling and callback serialization, see
 [Attach custom properties](../howto/attach_properties.md).
+
+Next: [Analyze Results](analysis.md).

--- a/docs/source/tutorial/units_interoperability.md
+++ b/docs/source/tutorial/units_interoperability.md
@@ -31,15 +31,15 @@ print(tracker.result_units)
 
 ## Model Units
 
-`LocalBarrierModel` barriers are in meV.
+[`LocalBarrierModel`](../modules/local_barrier_model.rst) barriers are in meV.
 
-`LocalClusterExpansion` fitted targets are in meV. If the LCE is used as a
-`kra_model`, the fitted target is `E_KRA`. If it is used as a `site_model`, the
-fitted target is the site-energy-difference contribution expected by the
-composite model.
+[`LocalClusterExpansion`](../modules/local_cluster_expansion.rst) fitted targets
+are in meV. If the LCE is used as a `kra_model`, the fitted target is `E_KRA`.
+If it is used as a `site_model`, the fitted target is the site-energy-difference
+contribution expected by the composite model.
 
-`SiteEnergyModel` can accept external values in `eV` or `meV` through its
-`units` argument and converts them to meV for kMCpy.
+[`SiteEnergyModel`](../modules/site_energy.rst) can accept external values in
+`eV` or `meV` through its `units` argument and converts them to meV for kMCpy.
 
 ## Differences From Other Codes
 


### PR DESCRIPTION
This pull request reorganizes and clarifies the kMCpy documentation, especially the tutorials and workflow guidance. The main improvements are to the structure and clarity of the beginner and advanced tutorials, making it easier for users to follow the correct workflow for different model branches (LocalBarrierModel vs. LocalClusterExpansion), and providing more explicit guidance and explanations for each step.

**Documentation Structure and Navigation Improvements:**

- Renamed and restructured tutorial and reference section titles throughout the docs for consistency and clarity (e.g., "Beginner Tutorial" → "Workflow Overview", "Reference" → "Reference Overview", "Advanced Tutorials" → "Advanced Overview"). [[1]](diffhunk://#diff-eb02e31d1a90d25273fe027e15cbd390ce9e299c79441d3555902620f8897da5L1-R30) [[2]](diffhunk://#diff-3ab6902a38dcc6d93172ba7e52a6dd0c880b5a1b39c6490df76b3e6a896813cfL1-R6) [[3]](diffhunk://#diff-bab889f184236f7af08a82d178c4395999e0071b0a1de20c8b84f486f2c87a15L1-R6) [[4]](diffhunk://#diff-4eec6cec5f6fab1548b85433ea8ca81315ae165db4b7f84019f287df9015699fL54-R66)
- Reordered the main index and navigation to present theory before tutorials, and clarified the recommended order for new users. [[1]](diffhunk://#diff-4eec6cec5f6fab1548b85433ea8ca81315ae165db4b7f84019f287df9015699fL37-R38) [[2]](diffhunk://#diff-4eec6cec5f6fab1548b85433ea8ca81315ae165db4b7f84019f287df9015699fL54-R66)

**Workflow and Tutorial Content Enhancements:**

- Updated the main tutorial (`tutorial/index.md`) to clearly distinguish between the "local barrier" and "LCE" model branches, providing step-by-step guidance for both, and clarified which pages are relevant depending on the chosen workflow. [[1]](diffhunk://#diff-eb02e31d1a90d25273fe027e15cbd390ce9e299c79441d3555902620f8897da5L1-R30) [[2]](diffhunk://#diff-eb02e31d1a90d25273fe027e15cbd390ce9e299c79441d3555902620f8897da5L36-R61) [[3]](diffhunk://#diff-441a37f5c63828d6976bdf24a3764797fb032e6604a5722187a4c8e507adb752L3-R15)
- Added explicit "Next" step links at the end of key tutorial pages to guide users through the correct workflow sequence. [[1]](diffhunk://#diff-ddc7393b51d5e5bf52b927998f122a53669fa7364d0eec0c3fb77a65d96f39c4L67-R70) [[2]](diffhunk://#diff-7f32e374047d6d23f29b4592a75b0ad539bd84ec2abbcbfdf8b33a7fb4f9fffeR111-R112) [[3]](diffhunk://#diff-441a37f5c63828d6976bdf24a3764797fb032e6604a5722187a4c8e507adb752R130-R131) [[4]](diffhunk://#diff-636b6e57a974c3988c6ea9813ca0040626943c2c23e5405e77b11ea39ceb61a8R99-R103)

**Detailed Explanations and API Guidance:**

- Expanded documentation for LCE fitting and NEB data preparation, including detailed argument lists for important functions, clarifying the relationship between local environments, NEB endpoints, and model fitting, and providing more concrete code examples. [[1]](diffhunk://#diff-7f32e374047d6d23f29b4592a75b0ad539bd84ec2abbcbfdf8b33a7fb4f9fffeL3-R9) [[2]](diffhunk://#diff-7f32e374047d6d23f29b4592a75b0ad539bd84ec2abbcbfdf8b33a7fb4f9fffeL64-R72) [[3]](diffhunk://#diff-7f32e374047d6d23f29b4592a75b0ad539bd84ec2abbcbfdf8b33a7fb4f9fffeR82-R83) [[4]](diffhunk://#diff-441a37f5c63828d6976bdf24a3764797fb032e6604a5722187a4c8e507adb752R34-R83) [[5]](diffhunk://#diff-441a37f5c63828d6976bdf24a3764797fb032e6604a5722187a4c8e507adb752R94-R117)
- Improved explanations of event library generation and the significance of the `site_mapping` and active-site order, with detailed descriptions of required arguments. [[1]](diffhunk://#diff-636b6e57a974c3988c6ea9813ca0040626943c2c23e5405e77b11ea39ceb61a8L5-R7) [[2]](diffhunk://#diff-636b6e57a974c3988c6ea9813ca0040626943c2c23e5405e77b11ea39ceb61a8R36-R50)

**Terminology and Reference Consistency:**

- Standardized terminology across the docs, e.g., referring to the main workflow as the "workflow tutorial", and consistently referencing advanced and workflow pages. [[1]](diffhunk://#diff-98c97087e02814f18024aa315b17fa112c6e45b4f9101a1e3d62116d00d26114L11-R11) [[2]](diffhunk://#diff-b02c4752ca81c0e99f7ddf56d7a6c70139ac7b66d34884dbbc65f797657caeeaL72-R72) [[3]](diffhunk://#diff-3ab6902a38dcc6d93172ba7e52a6dd0c880b5a1b39c6490df76b3e6a896813cfL1-R6) [[4]](diffhunk://#diff-bab889f184236f7af08a82d178c4395999e0071b0a1de20c8b84f486f2c87a15L21-R23) [[5]](diffhunk://#diff-13b1ee66b3da46e02f8e3cbdcd9bcca91a0a9899d7af31d585a2f45798e24965R3-R6)

**Clarifications for Advanced Users:**

- Clarified the distinction between beginner and advanced pages, and improved links between them for users seeking customization or deeper details. [[1]](diffhunk://#diff-bab889f184236f7af08a82d178c4395999e0071b0a1de20c8b84f486f2c87a15L1-R6) [[2]](diffhunk://#diff-3ab6902a38dcc6d93172ba7e52a6dd0c880b5a1b39c6490df76b3e6a896813cfL1-R6) [[3]](diffhunk://#diff-4eec6cec5f6fab1548b85433ea8ca81315ae165db4b7f84019f287df9015699fL54-R66)

These changes make the documentation easier to navigate and understand for both new and advanced users, and ensure that users can follow the correct workflow for their chosen modeling approach.

---

**References:**

- Documentation structure and navigation: [[1]](diffhunk://#diff-eb02e31d1a90d25273fe027e15cbd390ce9e299c79441d3555902620f8897da5L1-R30) [[2]](diffhunk://#diff-3ab6902a38dcc6d93172ba7e52a6dd0c880b5a1b39c6490df76b3e6a896813cfL1-R6) [[3]](diffhunk://#diff-bab889f184236f7af08a82d178c4395999e0071b0a1de20c8b84f486f2c87a15L1-R6) [[4]](diffhunk://#diff-4eec6cec5f6fab1548b85433ea8ca81315ae165db4b7f84019f287df9015699fL54-R66) [[5]](diffhunk://#diff-4eec6cec5f6fab1548b85433ea8ca81315ae165db4b7f84019f287df9015699fL37-R38)
- Workflow and tutorial content: [[1]](diffhunk://#diff-eb02e31d1a90d25273fe027e15cbd390ce9e299c79441d3555902620f8897da5L1-R30) [[2]](diffhunk://#diff-eb02e31d1a90d25273fe027e15cbd390ce9e299c79441d3555902620f8897da5L36-R61) [[3]](diffhunk://#diff-441a37f5c63828d6976bdf24a3764797fb032e6604a5722187a4c8e507adb752L3-R15) [[4]](diffhunk://#diff-ddc7393b51d5e5bf52b927998f122a53669fa7364d0eec0c3fb77a65d96f39c4L67-R70) [[5]](diffhunk://#diff-7f32e374047d6d23f29b4592a75b0ad539bd84ec2abbcbfdf8b33a7fb4f9fffeR111-R112) [[6]](diffhunk://#diff-441a37f5c63828d6976bdf24a3764797fb032e6604a5722187a4c8e507adb752R130-R131) [[7]](diffhunk://#diff-636b6e57a974c3988c6ea9813ca0040626943c2c23e5405e77b11ea39ceb61a8R99-R103)
- Detailed explanations and API guidance: [[1]](diffhunk://#diff-7f32e374047d6d23f29b4592a75b0ad539bd84ec2abbcbfdf8b33a7fb4f9fffeL3-R9) [[2]](diffhunk://#diff-7f32e374047d6d23f29b4592a75b0ad539bd84ec2abbcbfdf8b33a7fb4f9fffeL64-R72) [[3]](diffhunk://#diff-7f32e374047d6d23f29b4592a75b0ad539bd84ec2abbcbfdf8b33a7fb4f9fffeR82-R83) [[4]](diffhunk://#diff-441a37f5c63828d6976bdf24a3764797fb032e6604a5722187a4c8e507adb752R34-R83) [[5]](diffhunk://#diff-441a37f5c63828d6976bdf24a3764797fb032e6604a5722187a4c8e507adb752R94-R117) [[6]](diffhunk://#diff-636b6e57a974c3988c6ea9813ca0040626943c2c23e5405e77b11ea39ceb61a8L5-R7) [[7]](diffhunk://#diff-636b6e57a974c3988c6ea9813ca0040626943c2c23e5405e77b11ea39ceb61a8R36-R50)
- Terminology and reference consistency: [[1]](diffhunk://#diff-98c97087e02814f18024aa315b17fa112c6e45b4f9101a1e3d62116d00d26114L11-R11) [[2]](diffhunk://#diff-b02c4752ca81c0e99f7ddf56d7a6c70139ac7b66d34884dbbc65f797657caeeaL72-R72) [[3]](diffhunk://#diff-3ab6902a38dcc6d93172ba7e52a6dd0c880b5a1b39c6490df76b3e6a896813cfL1-R6) [[4]](diffhunk://#diff-bab889f184236f7af08a82d178c4395999e0071b0a1de20c8b84f486f2c87a15L21-R23) [[5]](diffhunk://#diff-13b1ee66b3da46e02f8e3cbdcd9bcca91a0a9899d7af31d585a2f45798e24965R3-R6)
- Advanced user clarifications: [[1]](diffhunk://#diff-bab889f184236f7af08a82d178c4395999e0071b0a1de20c8b84f486f2c87a15L1-R6) [[2]](diffhunk://#diff-3ab6902a38dcc6d93172ba7e52a6dd0c880b5a1b39c6490df76b3e6a896813cfL1-R6) [[3]](diffhunk://#diff-4eec6cec5f6fab1548b85433ea8ca81315ae165db4b7f84019f287df9015699fL54-R66)